### PR TITLE
Export errors and events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,8 @@
 
 const Consumer = require('./consumer')
 const Producer = require('./producer')
+const errors = require('./errors')
+const events = require('./events')
 
 /**
  * Queue module for Jellyfish.
@@ -15,3 +17,5 @@ const Producer = require('./producer')
 
 exports.Consumer = Consumer
 exports.Producer = Producer
+exports.errors = errors
+exports.events = events


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

***

Exporting `errors` and `events` as they are required in integration tests:
https://github.com/product-os/jellyfish/blob/master/test/integration/queue/helpers.js#L14
https://github.com/product-os/jellyfish/blob/master/test/integration/queue/events.spec.js#L11