### PR TITLE
Use the new `linkCards` API to link the action request and it's event.

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -19,38 +19,15 @@ const metrics = require('@balena/jellyfish-metrics')
  * @module queue
  */
 
-const LINK_EXECUTE = {
-	NAME: 'executes',
-	INVERSE_NAME: 'is executed by'
-}
-
-const EXECUTE_LINK_VERSION = '1.0.0'
-
 const RUN_RETRIES = 10
 const RUN_RETRY_DELAY = 1000
 
-const getExecuteLinkSlug = (actionRequest) => {
-	return `link-execute-${actionRequest.slug}`
-}
-
-const linkExecuteEvent = (jellyfish, context, session, eventCard, actionRequest) => {
-	return jellyfish.insertCard(context, session, {
-		slug: getExecuteLinkSlug(actionRequest),
-		type: 'link@1.0.0',
-		version: EXECUTE_LINK_VERSION,
-		name: LINK_EXECUTE.NAME,
-		data: {
-			inverseName: LINK_EXECUTE.INVERSE_NAME,
-			from: {
-				id: eventCard.id,
-				type: eventCard.type
-			},
-			to: {
-				id: actionRequest.id,
-				type: actionRequest.type
-			}
-		}
-	})
+const linkExecuteEvent = async (jellyfish, context, session, eventCard, actionRequest) => {
+	return jellyfish.linkCards(context,
+		session,
+		eventCard,
+		actionRequest,
+		'relationship-is-executed-by-executes@1.0.0')
 }
 
 module.exports = class Consumer {


### PR DESCRIPTION
**This PR will need to wait until after https://github.com/product-os/jellyfish/pull/4416 is merged, but then it's GTG.**

Use the new jellyfish `linkCards` API to link the action request and executes cards.
