### PR TITLE
renovate: Disable bumps for Jellyfish lib devDependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,6 +29,11 @@
         "patch"
       ],
       "automerge": true
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "packagePatterns": ["@balena/jellyfish-*"],
+      "enabled": false
     }
   ],
   "encrypted": {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add a package rule group to our renovate config to disable bumps for `@balena/jellyfish-*` devDependencies. Need to do this so we don't end up in an infinite bump loop now that we are moving more tests into this repo.