### PR TITLE
renovate: Enable docker base image bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,11 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "docker:enableMajor"
   ],
   "enabledManagers": [
-    "npm"
+    "npm",
+    "dockerfile"
   ],
   "force": {
     "constraints": {


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Enable renovate to bump base image versions in our dockerfiles now that we use them for integration tests.