### PR TITLE
Only ignore patch and minor devDependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,6 +35,10 @@
     {
       "depTypeList": ["devDependencies"],
       "packagePatterns": ["@balena/jellyfish-*"],
+      "updateTypes": [
+        "minor",
+        "patch"
+      ],
       "enabled": false
     }
   ],


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>

***

Minor fix to specify the update types for the new devDependencies renovate rule for jellyfish dev dependencies.