### PR TITLE
Ensure graphile-worker is initialized in producer

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -4,10 +4,13 @@
  * Proprietary and confidential.
  */
 
+const _ = require('lodash')
 const Bluebird = require('bluebird')
 const uuid = require('@balena/jellyfish-uuid')
+const graphileWorker = require('graphile-worker')
 const logger = require('@balena/jellyfish-logger').getLogger(__filename)
 const assert = require('@balena/jellyfish-assert')
+const environment = require('@balena/jellyfish-environment')
 const errors = require('./errors')
 const events = require('./events')
 const CARDS = require('./cards')
@@ -30,6 +33,26 @@ module.exports = class Producer {
 		await Bluebird.map(Object.values(CARDS), async (card) => {
 			return this.jellyfish.replaceCard(context, this.session, card)
 		})
+
+		// Run the graphile worker once with a dummy task to ensure that the
+		// graphile_worker schema exists in the DB before we attempt to enqueue a job.
+		try {
+			await graphileWorker.runOnce({
+				noHandleSignals: true,
+				pgPool: this.jellyfish.backend.connection.$pool,
+				concurrency: environment.queue.concurrency,
+				pollInterval: 1000,
+				logger: new graphileWorker.Logger((scope) => {
+					return _.noop
+				}),
+				taskList: {
+					_dummy: _.noop
+				}
+			})
+		} catch (error) {
+			logger.error(context, 'Failed to initialize graphileWorker in queue producer', error)
+			throw error
+		}
 	}
 
 	// FIXME this function exists solely for the purpose of allowing upstream code


### PR DESCRIPTION
Run the graphile worker once (for a dummy task) and then exit in the producer's initialize method. This ensures that the graphile_worker schema is added to the DB and the enqueue method will not throw an exception if the consumer hasn't been started yet.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>