### PR TITLE
Use graphileWorker.makeWorkerUtils in producer

### DIFF
--- a/lib/producer.js
+++ b/lib/producer.js
@@ -4,13 +4,11 @@
  * Proprietary and confidential.
  */
 
-const _ = require('lodash')
 const Bluebird = require('bluebird')
 const uuid = require('@balena/jellyfish-uuid')
 const graphileWorker = require('graphile-worker')
 const logger = require('@balena/jellyfish-logger').getLogger(__filename)
 const assert = require('@balena/jellyfish-assert')
-const environment = require('@balena/jellyfish-environment')
 const errors = require('./errors')
 const events = require('./events')
 const CARDS = require('./cards')
@@ -34,25 +32,12 @@ module.exports = class Producer {
 			return this.jellyfish.replaceCard(context, this.session, card)
 		})
 
-		// Run the graphile worker once with a dummy task to ensure that the
-		// graphile_worker schema exists in the DB before we attempt to enqueue a job.
-		try {
-			await graphileWorker.runOnce({
-				noHandleSignals: true,
-				pgPool: this.jellyfish.backend.connection.$pool,
-				concurrency: environment.queue.concurrency,
-				pollInterval: 1000,
-				logger: new graphileWorker.Logger((scope) => {
-					return _.noop
-				}),
-				taskList: {
-					_dummy: _.noop
-				}
-			})
-		} catch (error) {
-			logger.error(context, 'Failed to initialize graphileWorker in queue producer', error)
-			throw error
-		}
+		// Set up the graphile worker to ensure that the graphile_worker schema
+		// exists in the DB before we attempt to enqueue a job.
+		const workerUtils = await graphileWorker.makeWorkerUtils({
+			pgPool: this.jellyfish.backend.connection.$pool
+		})
+		workerUtils.release()
 	}
 
 	// FIXME this function exists solely for the purpose of allowing upstream code


### PR DESCRIPTION
This is a more correct way to initialize the graphile_worker schema in the producer.

Change-type: patch
Signed-off-by: Graham McCulloch <graham@balena.io>