### PR TITLE
Fix incorrect typings

### DIFF
--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -18,7 +18,6 @@ import {
 	Context,
 	JellyfishKernel,
 	LinkContract,
-	LinkData,
 } from '@balena/jellyfish-types/build/core';
 import { core } from '@balena/jellyfish-types';
 import {
@@ -51,7 +50,7 @@ const linkExecuteEvent = async (
 	eventCard: ExecuteContract,
 	actionRequest: ActionRequestContract,
 ): Promise<LinkContract> => {
-	return jellyfish.insertCard<LinkData>(context, session, {
+	return jellyfish.insertCard<LinkContract>(context, session, {
 		slug: getExecuteLinkSlug(actionRequest),
 		type: 'link@1.0.0',
 		version: EXECUTE_LINK_VERSION,

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -122,7 +122,7 @@ export const post = async (
 		contents.data.originator = options.originator;
 	}
 
-	return jellyfish.insertCard(context, session, contents);
+	return jellyfish.insertCard<ExecuteContract>(context, session, contents);
 };
 
 /**

--- a/lib/producer.ts
+++ b/lib/producer.ts
@@ -13,7 +13,6 @@ import type {
 import {
 	ActionContract,
 	ActionRequestContract,
-	ActionRequestData,
 	Context,
 	JellyfishKernel,
 	SessionContract,
@@ -132,7 +131,7 @@ export class Producer implements QueueProducer {
 
 		// Use the Queue's session instead of the session passed as a parameter as the
 		// passed session shouldn't have permissions to create action requests
-		return this.jellyfish.insertCard<ActionRequestData>(
+		return this.jellyfish.insertCard<ActionRequestContract>(
 			options.context,
 			this.session,
 			{


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>

---

Fix a few typing mistakes that causes the following errors on build:
```
lib/consumer.ts:54:2 - error TS2740: Type 'LinkData' is missing the following properties from type 'Contract<LinkData, { [key: string]: Contract<ContractData, ...>[]; }>': id, version, slug, type, and 7 more.

 54  return jellyfish.insertCard<LinkData>(context, session, {
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 55   slug: getExecuteLinkSlug(actionRequest),
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
... 
 69   },
    ~~~~
 70  });
    ~~~~

lib/consumer.ts:54:30 - error TS2344: Type 'LinkData' does not satisfy the constraint 'Contract<ContractData, { [key: string]: Contract<ContractData, ...>[]; }>'.
  Type 'LinkData' is missing the following properties from type 'Contract<ContractData, { [key: string]: Contract<ContractData, ...>[]; }>': id, version, slug, type, and 7 more.

54  return jellyfish.insertCard<LinkData>(context, session, {
                                ~~~~~~~~

lib/events.ts:125:2 - error TS2322: Type 'Contract<ContractData, { [key: string]: Contract<ContractData, ...>[]; }>' is not assignable to type 'ExecuteContract'.
  Type 'ContractData' is missing the following properties from type 'ExecuteData': actor, target, payload, timestamp

125  return jellyfish.insertCard(context, session, contents);
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

lib/producer.ts:135:3 - error TS2740: Type 'ActionRequestData' is missing the following properties from type 'Contract<ActionRequestData, { [key: string]: Contract<ContractData, ...>[]; }>': id, version, slug, type, and 7 more.

135   return this.jellyfish.insertCard<ActionRequestData>(
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
136    options.context,
    ~~~~~~~~~~~~~~~~~~~
... 
153    },
    ~~~~~
154   );
    ~~~~

lib/producer.ts:135:36 - error TS2344: Type 'ActionRequestData' does not satisfy the constraint 'Contract<ContractData, { [key: string]: Contract<ContractData, ...>[]; }>'.
  Type 'ActionRequestData' is missing the following properties from type 'Contract<ContractData, { [key: string]: Contract<ContractData, ...>[]; }>': id, version, slug, type, and 7 more.

135   return this.jellyfish.insertCard<ActionRequestData>(
                                       ~~~~~~~~~~~~~~~~~


Found 5 errors.
```