### PR TITLE
Add support for scheduled actions

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -42,6 +42,7 @@ export interface ActionRequestData {
 	};
 	timestamp: string;
 	originator?: string;
+	schedule?: string;
 	[k: string]: unknown;
 }
 


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add support for scheduled actions into the queue, namely converting scheduled action configuration to graphile worker job options.