### PR TITLE
Revert the reordering in v2.0.0 in `lib/errors.ts`

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,5 +1,5 @@
-import { JellyfishError } from '@balena/jellyfish-types';
 import { TypedError } from 'typed-error';
+import { JellyfishError } from '@balena/jellyfish-types';
 
 export class BaseTypedError extends TypedError implements JellyfishError {
 	expected: boolean = false;


### PR DESCRIPTION
Desperate attempt to fix the problem in this PR: https://github.com/product-os/jellyfish-action-library/pull/1454

Change-type: patch
Signed-off-by: Carol Schulze <carol@balena.io>