### PR TITLE
Add action and action-request contracts/types

### DIFF
--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -7,12 +7,10 @@ import type { Pool } from 'pg';
 import { once, noop } from 'lodash';
 import { contracts } from './contracts';
 import { Kernel } from '@balena/jellyfish-core';
-import {
-	ActionRequestContract,
-	LinkContract,
-} from '@balena/jellyfish-types/build/core';
+import { LinkContract } from '@balena/jellyfish-types/build/core';
 import { ExecuteContract } from '@balena/jellyfish-types/build/queue';
 import { post } from './events';
+import type { ActionRequestContract } from './types';
 
 const logger = getLogger(__filename);
 

--- a/lib/contracts/action-request.ts
+++ b/lib/contracts/action-request.ts
@@ -1,0 +1,69 @@
+export const actionRequest = {
+	slug: 'action-request',
+	type: 'type@1.0.0',
+	name: 'Jellyfish Action Request',
+	data: {
+		schema: {
+			type: 'object',
+			properties: {
+				slug: {
+					type: 'string',
+					pattern: '^action-request-[a-z0-9-]+$',
+				},
+				type: {
+					type: 'string',
+					enum: ['action-request', 'action-request@1.0.0'],
+				},
+				data: {
+					type: 'object',
+					properties: {
+						epoch: {
+							type: 'number',
+						},
+						timestamp: {
+							type: 'string',
+							format: 'date-time',
+						},
+						context: {
+							type: 'object',
+						},
+						originator: {
+							type: 'string',
+							format: 'uuid',
+						},
+						actor: {
+							type: 'string',
+							format: 'uuid',
+						},
+						action: {
+							type: 'string',
+						},
+						input: {
+							type: 'object',
+							required: ['id'],
+							properties: {
+								id: {
+									type: 'string',
+									format: 'uuid',
+								},
+							},
+						},
+						arguments: {
+							type: 'object',
+						},
+					},
+					required: [
+						'epoch',
+						'timestamp',
+						'context',
+						'actor',
+						'action',
+						'input',
+						'arguments',
+					],
+				},
+			},
+			required: ['slug', 'type', 'data'],
+		},
+	},
+};

--- a/lib/contracts/action.ts
+++ b/lib/contracts/action.ts
@@ -1,0 +1,42 @@
+export const action = {
+	slug: 'action',
+	type: 'type@1.0.0',
+	name: 'Jellyfish action',
+	data: {
+		schema: {
+			type: 'object',
+			properties: {
+				slug: {
+					type: 'string',
+					pattern: '^action-[a-z0-9-]+$',
+				},
+				type: {
+					type: 'string',
+					enum: ['action', 'action@1.0.0'],
+				},
+				data: {
+					type: 'object',
+					properties: {
+						extends: {
+							type: 'string',
+							pattern: '^[a-z0-9-]+$',
+						},
+						filter: {
+							type: 'object',
+						},
+						arguments: {
+							type: 'object',
+							patternProperties: {
+								'^[a-z0-9]+$': {
+									type: 'object',
+								},
+							},
+						},
+					},
+					required: ['arguments'],
+				},
+			},
+			required: ['slug', 'type', 'data'],
+		},
+	},
+};

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -1,5 +1,9 @@
+import { action } from './action';
+import { actionRequest } from './action-request';
 import { execute } from './execute';
 
 export const contracts = {
+	action,
+	'action-request': actionRequest,
 	execute,
 };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,6 @@
 export { Consumer } from './consumer';
-export { Producer, ProducerOptions, ProducerResults } from './producer';
 export * as errors from './errors';
 export * as events from './events';
+export { Producer, ProducerOptions, ProducerResults } from './producer';
 export * as testUtils from './test-utils';
+export * from './types';

--- a/lib/producer.ts
+++ b/lib/producer.ts
@@ -3,8 +3,6 @@ import * as assert from '@balena/jellyfish-assert';
 import { Kernel } from '@balena/jellyfish-core';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
 import {
-	ActionContract,
-	ActionRequestContract,
 	ContractData,
 	SessionContract,
 } from '@balena/jellyfish-types/build/core';
@@ -21,6 +19,7 @@ import {
 	QueueInvalidRequest,
 	QueueNoRequest,
 } from './errors';
+import type { ActionContract, ActionRequestContract } from './types';
 
 const logger = getLogger(__filename);
 

--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -1,8 +1,8 @@
 import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
-import type { ActionRequestContract } from '@balena/jellyfish-types/build/core';
 import { v4 as uuidv4 } from 'uuid';
 import { Consumer } from './consumer';
 import { Producer } from './producer';
+import type { ActionRequestContract } from './types';
 
 /**
  * Context that can be used in tests against the queue.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,50 @@
+import type {
+	Contract,
+	ContractDefinition,
+} from '@balena/jellyfish-types/build/core';
+
+export interface ActionData {
+	filter?: {
+		[k: string]: unknown;
+	};
+	extends?: string;
+	arguments: {
+		/**
+		 * This interface was referenced by `undefined`'s JSON-Schema definition
+		 * via the `patternProperty` "^[a-z0-9]+$".
+		 */
+		[k: string]: {
+			[k: string]: unknown;
+		};
+	};
+	[k: string]: unknown;
+}
+
+export interface ActionContractDefinition
+	extends ContractDefinition<ActionData> {}
+
+export interface ActionContract extends Contract<ActionData> {}
+
+export interface ActionRequestData {
+	actor: string;
+	epoch: number;
+	input: {
+		id: string;
+		[k: string]: unknown;
+	};
+	action: string;
+	context: {
+		[k: string]: unknown;
+	};
+	arguments: {
+		[k: string]: unknown;
+	};
+	timestamp: string;
+	originator?: string;
+	[k: string]: unknown;
+}
+
+export interface ActionRequestContractDefinition
+	extends ContractDefinition<ActionRequestData> {}
+
+export interface ActionRequestContract extends Contract<ActionRequestData> {}

--- a/test/integration/queue/index.spec.ts
+++ b/test/integration/queue/index.spec.ts
@@ -1,11 +1,12 @@
 import { errors as coreErrors, Kernel } from '@balena/jellyfish-core';
+import { Contract, SessionContract } from '@balena/jellyfish-types/build/core';
 import {
 	ActionContract,
 	ActionRequestContract,
-	Contract,
-	SessionContract,
-} from '@balena/jellyfish-types/build/core';
-import { errors, ProducerOptions, testUtils } from '../../../lib';
+	errors,
+	ProducerOptions,
+	testUtils,
+} from '../../../lib';
 
 let context: testUtils.TestContext;
 


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Add `action` and `action-request` contracts and their type definitions.