### PR TITLE
Bring in ExecuteContract type

### DIFF
--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -1,16 +1,15 @@
+import { Kernel } from '@balena/jellyfish-core';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
 import * as metrics from '@balena/jellyfish-metrics';
+import type { LinkContract } from '@balena/jellyfish-types/build/core';
 import { Logger } from '@graphile/logger';
 import * as graphileWorker from 'graphile-worker';
+import _ from 'lodash';
 import type { Pool } from 'pg';
-import { once, noop } from 'lodash';
 import { contracts } from './contracts';
-import { Kernel } from '@balena/jellyfish-core';
-import { LinkContract } from '@balena/jellyfish-types/build/core';
-import { ExecuteContract } from '@balena/jellyfish-types/build/queue';
 import { post } from './events';
-import type { ActionRequestContract } from './types';
+import type { ActionRequestContract, ExecuteContract } from './types';
 
 const logger = getLogger(__filename);
 
@@ -118,7 +117,7 @@ export class Consumer implements QueueConsumer {
 		);
 
 		await this.run(logContext, onMessageEventHandler);
-		this.graphileRunner!.stop = once(this.graphileRunner!.stop);
+		this.graphileRunner!.stop = _.once(this.graphileRunner!.stop);
 	}
 
 	async run(
@@ -133,7 +132,7 @@ export class Consumer implements QueueConsumer {
 				concurrency: defaultEnvironment.queue.concurrency,
 				pollInterval: 1000,
 				logger: new Logger((_scope) => {
-					return noop;
+					return _.noop;
 				}),
 				taskList: {
 					actionRequest: async (result) => {

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,11 +1,8 @@
 import { Kernel } from '@balena/jellyfish-core';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
-import {
-	ExecuteContract,
-	ExecuteContractDefinition,
-} from '@balena/jellyfish-types/build/queue';
 import { JsonSchema } from '@balena/jellyfish-types';
-import { PostResults, PostOptions } from './consumer';
+import type { PostOptions, PostResults } from './consumer';
+import type { ExecuteContract, ExecuteContractDefinition } from './types';
 
 const logger = getLogger(__filename);
 

--- a/lib/producer.ts
+++ b/lib/producer.ts
@@ -1,4 +1,3 @@
-import { strict as nativeAssert } from 'assert';
 import * as assert from '@balena/jellyfish-assert';
 import { Kernel } from '@balena/jellyfish-core';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
@@ -6,20 +5,24 @@ import {
 	ContractData,
 	SessionContract,
 } from '@balena/jellyfish-types/build/core';
-import { ExecuteContract } from '@balena/jellyfish-types/build/queue';
+import { strict as nativeAssert } from 'assert';
 import * as graphileWorker from 'graphile-worker';
 import { v4 as isUUID } from 'is-uuid';
 import type { Pool } from 'pg';
 import { v4 as uuidv4 } from 'uuid';
 import { contracts } from './contracts';
-import { getLastExecutionEvent, wait } from './events';
 import {
-	QueueInvalidSession,
 	QueueInvalidAction,
 	QueueInvalidRequest,
+	QueueInvalidSession,
 	QueueNoRequest,
 } from './errors';
-import type { ActionContract, ActionRequestContract } from './types';
+import { getLastExecutionEvent, wait } from './events';
+import type {
+	ActionContract,
+	ActionRequestContract,
+	ExecuteContract,
+} from './types';
 
 const logger = getLogger(__filename);
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -48,3 +48,32 @@ export interface ActionRequestContractDefinition
 	extends ContractDefinition<ActionRequestData> {}
 
 export interface ActionRequestContract extends Contract<ActionRequestData> {}
+
+export interface ExecuteData {
+	actor: string;
+	target: string;
+	payload: {
+		card: string;
+		data:
+			| {
+					[k: string]: unknown;
+			  }
+			| string
+			| number
+			| boolean
+			| unknown[]
+			| null;
+		error: boolean;
+		action: string;
+		timestamp: string;
+		[k: string]: unknown;
+	};
+	timestamp: string;
+	originator?: string;
+	[k: string]: unknown;
+}
+
+export interface ExecuteContractDefinition
+	extends ContractDefinition<ExecuteData> {}
+
+export interface ExecuteContract extends Contract<ExecuteData> {}


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Josh Bowling <josh@balena.io>

---

Bring in type related to the `execute` contract as that contract exist within this repository, reducing dependence on `jellyfish-types`. Also clean up some other imports.