### PR TITLE
Update the schema for action-request contracts to match LogContext

### DIFF
--- a/lib/contracts/action-request.ts
+++ b/lib/contracts/action-request.ts
@@ -26,6 +26,12 @@ export const actionRequest = {
 						},
 						context: {
 							type: 'object',
+							properties: {
+								id: {
+									type: 'string',
+								},
+							},
+							required: ['id'],
 						},
 						originator: {
 							type: 'string',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -35,6 +35,7 @@ export interface ActionRequestData {
 	action: string;
 	context: {
 		[k: string]: unknown;
+		id: string;
 	};
 	arguments: {
 		[k: string]: unknown;


### PR DESCRIPTION
The context value is an instance of
[`LogContext`](https://github.com/product-os/jellyfish-logger/blob/v4.0.32/lib/index.ts#L10),
and should always include an `id` field of type string.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>