### PR TITLE
Replace card with contract

### DIFF
--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -112,7 +112,7 @@ export class Consumer implements QueueConsumer {
 		logger.info(logContext, 'Inserting essential cards');
 		await Promise.all(
 			Object.values(contracts).map(async (card) => {
-				return this.kernel.replaceCard(logContext, this.session, card);
+				return this.kernel.replaceContract(logContext, this.session, card);
 			}),
 		);
 

--- a/lib/producer.ts
+++ b/lib/producer.ts
@@ -109,7 +109,7 @@ export class Producer implements QueueProducer {
 		logger.info(logContext, 'Inserting essential cards');
 		await Promise.all(
 			Object.values(contracts).map(async (card) => {
-				return this.kernel.replaceCard(logContext, this.session, card);
+				return this.kernel.replaceContract(logContext, this.session, card);
 			}),
 		);
 

--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -76,7 +76,7 @@ export const newContext = async (
 	// Initialize the producer first to ensure necessary types exist
 	await producer.initialize(coreTestContext.logContext);
 	await Promise.all([
-		await coreTestContext.kernel.insertCard(
+		await coreTestContext.kernel.insertContract(
 			coreTestContext.logContext,
 			coreTestContext.session,
 			actionCreateCard,


### PR DESCRIPTION
Replace calls to kernel methods from
the deprecated "card" variant to the
newer "contract" variant.

Change-type: patch
Signed-off-by: Josh Bowling <josh@balena.io>