### PR TITLE
Use autumndb instead of jellyfish-core

### DIFF
--- a/lib/consumer.ts
+++ b/lib/consumer.ts
@@ -1,4 +1,4 @@
-import { Kernel } from '@balena/jellyfish-core';
+import { Kernel } from 'autumndb';
 import { defaultEnvironment } from '@balena/jellyfish-environment';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
 import * as metrics from '@balena/jellyfish-metrics';

--- a/lib/events.ts
+++ b/lib/events.ts
@@ -1,4 +1,4 @@
-import { Kernel } from '@balena/jellyfish-core';
+import { Kernel } from 'autumndb';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
 import { JsonSchema } from '@balena/jellyfish-types';
 import type { PostOptions, PostResults } from './consumer';

--- a/lib/producer.ts
+++ b/lib/producer.ts
@@ -1,5 +1,5 @@
 import * as assert from '@balena/jellyfish-assert';
-import { Kernel } from '@balena/jellyfish-core';
+import { Kernel } from 'autumndb';
 import { getLogger, LogContext } from '@balena/jellyfish-logger';
 import {
 	ContractData,

--- a/lib/test-utils.ts
+++ b/lib/test-utils.ts
@@ -1,4 +1,4 @@
-import { testUtils as coreTestUtils } from '@balena/jellyfish-core';
+import { testUtils as coreTestUtils } from 'autumndb';
 import { v4 as uuidv4 } from 'uuid';
 import { Consumer } from './consumer';
 import { Producer } from './producer';

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@balena/jellyfish-assert": "^1.2.18",
-    "@balena/jellyfish-core": "^16.0.7",
     "@balena/jellyfish-environment": "^9.1.3",
     "@balena/jellyfish-logger": "^5.0.6",
     "@balena/jellyfish-metrics": "^2.0.47",
     "@graphile/logger": "^0.2.0",
+    "autumndb": "^17.0.3",
     "graphile-worker": "^0.12.2",
     "is-uuid": "^1.0.2",
     "lodash": "^4.17.21",

--- a/repo.yml
+++ b/repo.yml
@@ -1,12 +1,12 @@
-type: 'node'
+type: "node"
 upstream:
-  - repo: 'jellyfish-assert'
-    url: 'https://github.com/product-os/jellyfish-assert'
-  - repo: 'jellyfish-environment'
-    url: 'https://github.com/product-os/jellyfish-environment'
-  - repo: 'jellyfish-logger'
-    url: 'https://github.com/product-os/jellyfish-logger'
-  - repo: 'jellyfish-metrics'
-    url: 'https://github.com/product-os/jellyfish-metrics'
-  - repo: 'jellyfish-core'
-    url: 'https://github.com/product-os/jellyfish-core'
+  - repo: "jellyfish-assert"
+    url: "https://github.com/product-os/jellyfish-assert"
+  - repo: "jellyfish-environment"
+    url: "https://github.com/product-os/jellyfish-environment"
+  - repo: "jellyfish-logger"
+    url: "https://github.com/product-os/jellyfish-logger"
+  - repo: "jellyfish-metrics"
+    url: "https://github.com/product-os/jellyfish-metrics"
+  - repo: "autumndb"
+    url: "https://github.com/product-os/autumndb"

--- a/test/integration/events.spec.ts
+++ b/test/integration/events.spec.ts
@@ -2,7 +2,7 @@ import {
 	errors as coreErrors,
 	Kernel,
 	testUtils as coreTestUtils,
-} from '@balena/jellyfish-core';
+} from 'autumndb';
 import { strict as assert } from 'assert';
 import { omit } from 'lodash';
 import { events, testUtils } from '../../lib';

--- a/test/integration/index.spec.ts
+++ b/test/integration/index.spec.ts
@@ -1,4 +1,4 @@
-import { errors as coreErrors, Kernel } from '@balena/jellyfish-core';
+import { errors as coreErrors, Kernel } from 'autumndb';
 import { Contract, SessionContract } from '@balena/jellyfish-types/build/core';
 import {
 	ActionContract,


### PR DESCRIPTION
The `jellyfish-core` package has been renamed to `autumndb`.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>